### PR TITLE
added INSTANCE_BEFORE_METRIC and SEPARATE_ROLLUP parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
     <groupId>org.timconrad.vmstats</groupId>
     <artifactId>vmstats</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>

--- a/src/main/java/org/timconrad/vmstats/Main.java
+++ b/src/main/java/org/timconrad/vmstats/Main.java
@@ -201,6 +201,10 @@ public class Main {
         appConfig.put("SEND_ALL_ABSOLUTE", config.getProperty("SEND_ALL_ABSOLUTE"));
         appConfig.put("SEND_ALL_DELTA", config.getProperty("SEND_ALL_DELTA"));
         appConfig.put("DISCONNECT_GRAPHITE_AFTER", config.getProperty("DISCONNECT_GRAPHITE_AFTER"));
+        
+        appConfig.put("INSTANCE_BEFORE_METRIC", config.getProperty("INSTANCE_BEFORE_METRIC"));
+        appConfig.put("SEPARATE_ROLLUP", config.getProperty("SEPARATE_ROLLUP"));
+        
 
 		// Build internal data structures. 
 		

--- a/vmstats.default.properties
+++ b/vmstats.default.properties
@@ -23,6 +23,11 @@ GRAPHITE_TAG=vmstats
 # you probably want this enabled
 USE_FQDN=true
 
+#if you prefer instance names before metric name set this parameter to true
+INSTANCE_BEFORE_METRIC=false
+#if you prefer rollup name as part of the metric name set this parameter to false
+SEPARATE_ROLLUP=true
+
 # how long to sleep between loops in seconds
 # this must be divisible by 20
 SLEEP_TIME=300


### PR DESCRIPTION
This patch helps vmstats user to organize graphite tree in a different way ( with backwards compatibility) 

As response for 
https://github.com/Nordstrom/vmstats/issues/18